### PR TITLE
Support New Kits Source

### DIFF
--- a/atd-socrata-util/setup.py
+++ b/atd-socrata-util/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="atd-socrata-util",
-    version="0.0.5",
+    version="0.0.6",
     author="City of Austin",
     author_email="transportation.data@austintexas.gov",
     description="Utilities interacting with the Socrata Open Data API.",

--- a/atd-socrata-util/setup.py
+++ b/atd-socrata-util/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="atd-socrata-util",
-    version="0.0.4",
+    version="0.0.5",
     author="City of Austin",
     author_email="transportation.data@austintexas.gov",
     description="Utilities interacting with the Socrata Open Data API.",

--- a/atd-socrata-util/socratautil/socratautil.py
+++ b/atd-socrata-util/socratautil/socratautil.py
@@ -11,8 +11,6 @@ import requests
 
 from datautil import mills_to_unix, iso_to_unix, lower_case_keys
 
-import pdb
-
 
 class Soda(object):
     """
@@ -72,7 +70,7 @@ class Soda(object):
         if self.date_fields:
             if self.source == "knack":
                 self.records = mills_to_unix(self.records, self.date_fields)
-            elif self.source == "postgrest":
+            elif self.source == "postgrest" or self.source == "kits":
                 self.records = iso_to_unix(self.records, self.date_fields)
 
         self.records = lower_case_keys(self.records)


### PR DESCRIPTION
Related to [#230](https://github.com/cityofaustin/atd-data-publishing/issues/230).

Add support for a new `source=kits` parameter in the `Soda` class, which will handle the input dates as ISO strings.