### PR TITLE
Add New app_name Choices to Argutil

### DIFF
--- a/atd-args-util/argutil/_arguments.py
+++ b/atd-args-util/argutil/_arguments.py
@@ -33,6 +33,8 @@ ARGUMENTS = {
             "visitor_sign_in_prod",
             "dts_portal_test",
             "dts_portal_prod",
+            "signs_markings_prod",
+            "signs_markings_test"
         ],
         "type": str,
         "help": "Name of the knack application that will be accessed",

--- a/atd-args-util/setup.py
+++ b/atd-args-util/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="atd-args-util",
-    version="0.0.5",
+    version="0.0.6",
     author="City of Austin",
     author_email="transportation.data@austintexas.gov",
     description="Reusable argument parser for Python scripts.",


### PR DESCRIPTION
Adds `signs_markings_prod` and `signs_markings_test` as app_name choices to argutil.