### PR TITLE
Drop Fields with No Matching Metadata Column

### DIFF
--- a/atd-socrata-util/setup.py
+++ b/atd-socrata-util/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="atd-socrata-util",
-    version="0.0.6",
+    version="0.0.7",
     author="City of Austin",
     author_email="transportation.data@austintexas.gov",
     description="Utilities interacting with the Socrata Open Data API.",


### PR DESCRIPTION
Fixes [#257](https://github.com/cityofaustin/atd-data-publishing/issues/257).

The Socrata API now rejects payloads which contain fields that do not exist in the destination dataset. This PR builds a new `_drop_unknown_fieldnames()` method which removes fields that do not have a matching column in the socrata dataset metadata.