### PR TITLE
Forman Data Fields and Handle Nulls Properly

### DIFF
--- a/atd-socrata-util/setup.py
+++ b/atd-socrata-util/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="atd-socrata-util",
-    version="0.0.7",
+    version="0.0.8",
     author="City of Austin",
     author_email="transportation.data@austintexas.gov",
     description="Utilities interacting with the Socrata Open Data API.",


### PR DESCRIPTION
Fixes [#657](https://github.com/cityofaustin/atd-data-publishing/issues/257).

This PR handles null date fields by setting empty datestrings to `None`. It also fixes a bug, in which timestamps were not being properly converted from epoch milliseconds to epoch seconds. 