### PR TITLE
Update Date and Illegal Field Handling for new API Validations

### DIFF
--- a/atd-socrata-util/setup.py
+++ b/atd-socrata-util/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="atd-socrata-util",
-    version="0.0.6",
+    version="0.0.7",
     author="City of Austin",
     author_email="transportation.data@austintexas.gov",
     description="Utilities interacting with the Socrata Open Data API.",

--- a/atd-socrata-util/setup.py
+++ b/atd-socrata-util/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="atd-socrata-util",
-    version="0.0.7",
+    version="0.0.8",
     author="City of Austin",
     author_email="transportation.data@austintexas.gov",
     description="Utilities interacting with the Socrata Open Data API.",


### PR DESCRIPTION
Fixes [#657](https://github.com/cityofaustin/atd-data-publishing/issues/257) and fixes [#257](https://github.com/cityofaustin/atd-data-publishing/issues/257).

The Socrata API now rejects payloads which contain fields that do not exist in the destination dataset. It also no longer accepts empty datestrings for fields of type `date`.

This PR:

- provides a new `_drop_unknown_fieldnames()` method which removes fields that do not have a matching column in the socrata dataset metadata.

 - handles null date fields by setting empty datestrings to `None`. 

- fixes a bug in which timestamps were not being properly converted from epoch milliseconds to epoch seconds. 

