### PR TITLE
Handle `bcycle` Data Source

### DIFF
--- a/atd-socrata-util/setup.py
+++ b/atd-socrata-util/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="atd-socrata-util",
-    version="0.0.8",
+    version="0.0.9",
     author="City of Austin",
     author_email="transportation.data@austintexas.gov",
     description="Utilities interacting with the Socrata Open Data API.",

--- a/atd-socrata-util/socratautil/socratautil.py
+++ b/atd-socrata-util/socratautil/socratautil.py
@@ -6,6 +6,7 @@ in order to handle some common ETL routines, particularly with Knack integration
 """
 import json
 import os
+from pprint import pprint as print
 
 import requests
 
@@ -72,7 +73,7 @@ class Soda(object):
         if self.date_fields:
             if self.source == "knack":
                 self.records = mills_to_unix(self.records, self.date_fields)
-            elif self.source == "postgrest" or self.source == "kits":
+            elif self.source == "postgrest" or self.source == "kits" or self.source == "bcycle":
                 self.records = iso_to_unix(self.records, self.date_fields)
 
         # need to handle nulls after lowercase keys or the keys won't match the metdata


### PR DESCRIPTION
Continuing our updates to handle new socrata validations. Add a dedicated `bcycle` source to handle the expected iso-compliant date formats.