### PR TITLE
Handle new socrata date format

### DIFF
--- a/atd-data-util/datautil/datautil.py
+++ b/atd-data-util/datautil/datautil.py
@@ -149,7 +149,7 @@ def mills_to_iso(dicts, keys, tz="US/Central"):
 
 
 def mills_to_iso_socrata(dicts, keys, tz="US/Central"):
-    # convert millesecond date to ISO8601 date accepted by Socrata
+    # convert millisecond date to Socrata floating timestamp
     for record in dicts:
         for key in record:
             if key in keys:

--- a/atd-data-util/datautil/datautil.py
+++ b/atd-data-util/datautil/datautil.py
@@ -157,7 +157,7 @@ def mills_to_iso_socrata(dicts, keys, tz="US/Central"):
                     unix = float(record[key]) / 1000
                     utc = arrow.get(0).shift(seconds=unix)
                     local = utc.to(tz)
-                    record[key] = local.format('YYYY-MM-DDTHH:mm:ss')
+                    record[key] = local.format("YYYY-MM-DDTHH:mm:ss")
 
                 except ValueError:
                     #  handle empty values
@@ -399,9 +399,7 @@ def min_index(list_of_vals, val):
 def create_rank_list(dicts, rank_key_name):
     #  create 'rank' key and assign rank based on position of dict in list
     for record in dicts:
-        record[rank_key_name] = (
-            dicts.index(record) + 1
-        )  # because list indices start at
+        record[rank_key_name] = dicts.index(record) + 1  # because list indices start at
 
     return dicts
 

--- a/atd-data-util/datautil/datautil.py
+++ b/atd-data-util/datautil/datautil.py
@@ -129,27 +129,7 @@ def mills_to_unix(dicts, keys):
 
 
 def mills_to_iso(dicts, keys, tz="US/Central"):
-    # convert millesecond date to ISO8601 date
-    for record in dicts:
-        for key in record:
-            if key in keys:
-                try:
-                    unix = float(record[key]) / 1000
-                    utc = arrow.get(0).shift(seconds=unix)
-                    local = utc.to(tz)
-                    record[key] = local.format()
-
-                except ValueError:
-                    #  handle empty values
-                    if not record[key]:
-                        continue
-                    else:
-                        raise ValueError
-    return dicts
-
-
-def mills_to_iso_socrata(dicts, keys, tz="US/Central"):
-    # convert millisecond date to Socrata floating timestamp
+    # convert millisecond date to Socrata ISO8601 floating timestamp
     for record in dicts:
         for key in record:
             if key in keys:

--- a/atd-data-util/setup.py
+++ b/atd-data-util/setup.py
@@ -5,14 +5,11 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="atd-data-util",
-    version="0.0.2",
+    version="0.0.3",
     author="City of Austin",
     author_email="transportation.data@austintexas.gov",
     description="Miscellaneous utilities for manipulating data.",
-    install_requires=[
-      'requests',
-      'arrow'
-    ],
+    install_requires=["requests", "arrow"],
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/cityofaustin/atd-data-utilities/tree/master/atd-data-util",
@@ -21,7 +18,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "License :: Public Domain",
         "Operating System :: OS Independent",
-        "Development Status :: 4 - Beta", 
+        "Development Status :: 4 - Beta",
     ),
 )
-

--- a/atd-data-util/setup.py
+++ b/atd-data-util/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="atd-data-util",
-    version="0.0.3",
+    version="0.1.0",
     author="City of Austin",
     author_email="transportation.data@austintexas.gov",
     description="Miscellaneous utilities for manipulating data.",

--- a/atd-socrata-util/setup.py
+++ b/atd-socrata-util/setup.py
@@ -5,23 +5,19 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="atd-socrata-util",
-    version="0.0.9",
+    version="0.0.10",
     author="City of Austin",
     author_email="transportation.data@austintexas.gov",
     description="Utilities interacting with the Socrata Open Data API.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/cityofaustin/atd-data-utilities/tree/master/atd-socrata-util",
-    install_requires = [
-        "requests",
-        "atd-data-util"
-    ],
+    install_requires=["requests", "atd-data-util"],
     packages=setuptools.find_packages(),
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: Public Domain",
         "Operating System :: OS Independent",
-        "Development Status :: 4 - Beta", 
+        "Development Status :: 4 - Beta",
     ),
 )
-

--- a/atd-socrata-util/socratautil/socratautil.py
+++ b/atd-socrata-util/socratautil/socratautil.py
@@ -10,7 +10,7 @@ from pprint import pprint as print
 
 import requests
 
-from datautil import mills_to_unix, mills_to_iso, iso_to_unix, lower_case_keys
+from datautil import mills_to_unix, mills_to_iso_socrata, iso_to_unix, lower_case_keys
 
 
 class Soda(object):
@@ -80,9 +80,8 @@ class Soda(object):
 
         if self.calendar_date_fields:
             if self.source == "knack":
-                self.records = mills_to_iso(
+                self.records = mills_to_iso_socrata(
                     self.records, self.calendar_date_fields)
-                self.records = replace
 
         # need to handle nulls after lowercase keys or the keys won't match the metdata
         self._handle_nulls()
@@ -249,7 +248,7 @@ class Soda(object):
             for field in self.metadata["columns"]
             if "calendar_date" in field["dataTypeName"]
         ]
-        return self.date_fields
+        return self.calendar_date_fields
 
 
 def prepare_deletes(records, primary_key):

--- a/atd-socrata-util/socratautil/socratautil.py
+++ b/atd-socrata-util/socratautil/socratautil.py
@@ -35,7 +35,6 @@ class Soda(object):
     ):
 
         self.auth = auth
-        self.date_fields = date_fields
         self.host = host
         self.lat_field = lat_field
         self.lon_field = lon_field
@@ -118,7 +117,7 @@ class Soda(object):
         return self.records
 
     def _upload(self):
-        print(self.records[0])
+
         if self.replace:
             res = requests.put(self.url, json=self.records, auth=self.auth)
 
@@ -238,10 +237,11 @@ class Soda(object):
         self.date_fields = [
             field["fieldName"]
             for field in self.metadata["columns"]
-            if "date" in field["dataTypeName"]
+            if "date" == field["dataTypeName"]
         ]
         return self.date_fields
 
+    # Handle Socrata floating timestamp format
     def _get_calendar_date_fields(self):
         self.calendar_date_fields = [
             field["fieldName"]

--- a/atd-socrata-util/socratautil/socratautil.py
+++ b/atd-socrata-util/socratautil/socratautil.py
@@ -74,13 +74,18 @@ class Soda(object):
         if self.date_fields:
             if self.source == "knack":
                 self.records = mills_to_unix(self.records, self.date_fields)
-            elif self.source == "postgrest" or self.source == "kits" or self.source == "bcycle":
+            elif (
+                self.source == "postgrest"
+                or self.source == "kits"
+                or self.source == "bcycle"
+            ):
                 self.records = iso_to_unix(self.records, self.date_fields)
 
         if self.calendar_date_fields:
             if self.source == "knack":
                 self.records = mills_to_iso_socrata(
-                    self.records, self.calendar_date_fields)
+                    self.records, self.calendar_date_fields
+                )
 
         # need to handle nulls after lowercase keys or the keys won't match the metdata
         self._handle_nulls()


### PR DESCRIPTION
Closes part of https://github.com/cityofaustin/atd-data-tech/issues/1241

There are some formatting changes from using Black formatter. Also, I thought adding an optional format argument to the existing `mills_to_iso` method instead of creating a new one specifically for Socrata floating timestamp could be another option here. Just a thought.

 Links to metadata for old and new formats:
https://data.austintexas.gov/api/views/p53x-x73x.json (old)
https://data.austintexas.gov/api/views/p7pt-re4k.json (new)
